### PR TITLE
Update 01_todos.spec.js

### DIFF
--- a/cypress/integration/01_todos.spec.js
+++ b/cypress/integration/01_todos.spec.js
@@ -80,7 +80,7 @@ context('Todos', () => {
     // Each individual list should have the proper quantity
     cy.getByTestId('pending-list').children().should('have.length', 2);
     cy.getByTestId('paused-list').children().should('have.length', 0);
-    cy.getByTestId('completed-list').children().should('have.length', 1);
+    cy.get('#panel--1--0').children().should('have.length', 1);
   });
 
   it('Deletes todos', () => {


### PR DESCRIPTION
Updated Assertion on Line 83. If a user was to mark more than 1 item as complete, the original code would fail, as it appears to only count the DIV element.
Should a user mark 2 items as complete, the application only renders a single DIV.
Ive changed the line to allow for multiple items to be checked as completed and perform an assertion based on the panel.
Perhaps this isn't the best locator to use, but I have tested that the numbers within the ID do not increment each time the completed panel is rendered in the DOM.
In cases where an item is marked as completed, then all completed items are deleted, and new items then created and marked as completed.
I could be wrong in my approach, so happy for someone to correct me.